### PR TITLE
fix(models.py): add retries for transient network errors

### DIFF
--- a/modflow_devtools/models.py
+++ b/modflow_devtools/models.py
@@ -35,6 +35,7 @@ POOCH = pooch.create(
     base_url=BASE_URL,
     version=modflow_devtools.__version__,
     env="MFMODELS",
+    retry_if_failed=3,
 )
 
 


### PR DESCRIPTION
Network errors often crop up in CI. We want some resilience. Eventually it might be nice to make the retry count configurable somehow.