### PR TITLE
docs(models): fix docstring

### DIFF
--- a/modflow_devtools/models.py
+++ b/modflow_devtools/models.py
@@ -92,7 +92,7 @@ class LocalRegistry(ModelRegistry):
 
     *Not* persistent &mdash; lives only in memory, unlike `PoochRegistry`.
 
-    The registry is loaded lazily upon first access by recursively scanning
+    The registry is loaded eagerly on initialization by recursively scanning
     the given directory for models (located by the presence of a namefile)
     and corresponding input files.
 


### PR DESCRIPTION
The LocalRegistry was described as lazy but it is eager.