### PR TITLE
refactor(make_registry.py): shortcut to create default registry

### DIFF
--- a/docs/md/models.md
+++ b/docs/md/models.md
@@ -106,13 +106,13 @@ The script can be executed with `python -m modflow_devtools.make_registry`. It a
 - `--model-name-prefix`: Optionally specify a string to prepend to model names. Useful for avoiding collisions.
 - `--namefile`: Optionally specify the glob pattern for namefiles. By default, only `mfsim.nam` (MF6) are found.
 
-For example, to create a registry of models in the MF6 examples and test models repositories, assuming each is checked out next to this project:
+For example, to create the "default" registry of models in the MF6 examples and test models repositories, assuming each is checked out next to this project:
 
 ```shell
-python -m modflow_devtools.make_registry ../modflow6-examples/examples --url https://github.com/MODFLOW-ORG/modflow6-examples/releases/download/current/mf6examples.zip --model-name-prefix mf6/example
-python -m modflow_devtools.make_registry ../modflow6-testmodels/mf6 --append --url https://github.com/MODFLOW-ORG/modflow6-testmodels/raw/master/mf6 --model-name-prefix mf6/test
-python -m modflow_devtools.make_registry ../modflow6-largetestmodels --append --url https://github.com/MODFLOW-ORG/modflow6-largetestmodels/raw/master --model-name-prefix mf6/large
-python -m modflow_devtools.make_registry ../modflow6-testmodels/mf5to6 --append --url https://github.com/MODFLOW-ORG/modflow6-testmodels/raw/master/mf5to6 --model-name-prefix mf2005 --namefile "*.nam"
+python -m modflow_devtools.make_registry -p ../modflow6-examples/examples --url https://github.com/MODFLOW-ORG/modflow6-examples/releases/download/current/mf6examples.zip --model-name-prefix mf6/example
+python -m modflow_devtools.make_registry -p ../modflow6-testmodels/mf6 --append --url https://github.com/MODFLOW-ORG/modflow6-testmodels/raw/master/mf6 --model-name-prefix mf6/test
+python -m modflow_devtools.make_registry -p ../modflow6-largetestmodels --append --url https://github.com/MODFLOW-ORG/modflow6-largetestmodels/raw/master --model-name-prefix mf6/large
+python -m modflow_devtools.make_registry -p ../modflow6-testmodels/mf5to6 --append --url https://github.com/MODFLOW-ORG/modflow6-testmodels/raw/master/mf5to6 --model-name-prefix mf2005 --namefile "*.nam"
 ```
 
-Above we adopt a convention of prefixing model names with the model type (i.e. the program used to run it), e.g. "mf6/" or "mf2005/". Relative path parts below the initial prefix reflect the model's relative path within its repository.
+As a shortcut to create the default registry, the script can be run with no arguments: `python -m modflow_devtools.make_registry`.

--- a/modflow_devtools/make_registry.py
+++ b/modflow_devtools/make_registry.py
@@ -1,19 +1,46 @@
 import argparse
+from pathlib import Path
 
 import modflow_devtools.models as models
 
+_REPOS_PATH = Path(__file__).parents[2]
+_DEFAULT_REGISTRY_OPTIONS = [
+    {
+        "path": _REPOS_PATH / "modflow6-examples" / "examples",
+        "url": "https://github.com/MODFLOW-ORG/modflow6-examples/releases/download/current/mf6examples.zip",
+        "model-name-prefix": "mf6/example",
+    },
+    {
+        "path": _REPOS_PATH / "modflow6-testmodels" / "mf6",
+        "url": "https://github.com/MODFLOW-ORG/modflow6-testmodels/raw/master/mf6",
+        "model-name-prefix": "mf6/test",
+    },
+    {
+        "path": _REPOS_PATH / "modflow6-largetestmodels",
+        "url": "https://github.com/MODFLOW-ORG/modflow6-largetestmodels/raw/master",
+        "model-name-prefix": "mf6/large",
+    },
+    {
+        "path": _REPOS_PATH / "modflow6-testmodels" / "mf5to6",
+        "url": "https://github.com/MODFLOW-ORG/modflow6-testmodels/raw/master/mf5to6",
+        "model-name-prefix": "mf2005",
+        "namefile": "*.nam",
+    },
+]
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Make a registry of models.")
-    parser.add_argument("path")
     parser.add_argument(
-        "--append",
-        "-a",
-        action="store_true",
-        help="Append instead of overwriting.",
+        "--path",
+        "-p",
+        required=False,
+        default=None,
+        type=str,
+        help="Path to the model directory.",
     )
     parser.add_argument(
         "--model-name-prefix",
-        "-p",
         type=str,
         help="Prefix for model names.",
         default="",
@@ -32,14 +59,31 @@ if __name__ == "__main__":
         help="Namefile pattern to look for in the model directories.",
         default="mfsim.nam",
     )
-    args = parser.parse_args()
-    if not args.append:
-        models.DEFAULT_REGISTRY = models.PoochRegistry(
-            base_url=args.url, env=models._DEFAULT_ENV
-        )
-    models.DEFAULT_REGISTRY.index(
-        path=args.path,
-        url=args.url,
-        prefix=args.model_name_prefix,
-        namefile=args.namefile,
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show verbose output.",
     )
+    args = parser.parse_args()
+    if args.path:
+        if args.verbose:
+            print(f"Adding {args.path} to the registry.")
+        models.DEFAULT_REGISTRY.index(
+            path=args.path,
+            url=args.url,
+            prefix=args.model_name_prefix,
+            namefile=args.namefile,
+        )
+    else:
+        if args.verbose:
+            print("No path provided, creating default registry.")
+        for options in _DEFAULT_REGISTRY_OPTIONS:
+            if args.verbose:
+                print(f"Adding {options.path} to the registry.")
+            models.DEFAULT_REGISTRY.index(
+                path=options["path"],
+                url=options["url"],
+                prefix=options["model-name-prefix"],
+                namefile=options.get("namefile", "mfsim.nam"),
+            )

--- a/modflow_devtools/make_registry.py
+++ b/modflow_devtools/make_registry.py
@@ -80,10 +80,10 @@ if __name__ == "__main__":
             print("No path provided, creating default registry.")
         for options in _DEFAULT_REGISTRY_OPTIONS:
             if args.verbose:
-                print(f"Adding {options.path} to the registry.")
+                print(f"Adding {options['path']} to the registry.")
             models.DEFAULT_REGISTRY.index(
-                path=options["path"],
-                url=options["url"],
-                prefix=options["model-name-prefix"],
-                namefile=options.get("namefile", "mfsim.nam"),
+                path=options["path"],  # type: ignore
+                url=options["url"],  # type: ignore
+                prefix=options["model-name-prefix"],  # type: ignore
+                namefile=options.get("namefile", "mfsim.nam"),  # type: ignore
             )

--- a/modflow_devtools/models.py
+++ b/modflow_devtools/models.py
@@ -30,6 +30,12 @@ def _drop_none_or_empty(path, key, value):
     return True
 
 
+def _model_sort_key(k) -> int:
+    if "gwf" in k:
+        return 0
+    return 1
+
+
 def _sha256(path: Path) -> str:
     """
     Compute the SHA256 hash of the given file.
@@ -413,6 +419,9 @@ class PoochRegistry(ModelRegistry):
                     hash = _sha256(p)
                 files[name] = {"hash": hash, "url": url_}
                 models[model_name].append(name)
+
+        for example_name in examples.keys():
+            examples[example_name] = sorted(examples[example_name], key=_model_sort_key)
 
         with self._registry_file_path.open("ab+") as registry_file:
             tomli_w.dump(

--- a/modflow_devtools/registry/examples.toml
+++ b/modflow_devtools/registry/examples.toml
@@ -59,20 +59,20 @@ ex-gwf-csub-p02b = [
     "mf6/example/ex-gwf-csub-p02b",
 ]
 ex-gwf-csub-p02c = [
-    "mf6/example/ex-gwf-csub-p02c/hb-010",
-    "mf6/example/ex-gwf-csub-p02c/es-100",
-    "mf6/example/ex-gwf-csub-p02c/hb-005",
-    "mf6/example/ex-gwf-csub-p02c/es-050",
-    "mf6/example/ex-gwf-csub-p02c/hb-002",
-    "mf6/example/ex-gwf-csub-p02c/es-010",
-    "mf6/example/ex-gwf-csub-p02c/es-020",
+    "mf6/example/ex-gwf-csub-p02c/hb-020",
     "mf6/example/ex-gwf-csub-p02c/hb-100",
+    "mf6/example/ex-gwf-csub-p02c/hb-010",
+    "mf6/example/ex-gwf-csub-p02c/es-020",
     "mf6/example/ex-gwf-csub-p02c/es-005",
+    "mf6/example/ex-gwf-csub-p02c/es-010",
+    "mf6/example/ex-gwf-csub-p02c/hb-050",
     "mf6/example/ex-gwf-csub-p02c/hb-001",
     "mf6/example/ex-gwf-csub-p02c/es-001",
-    "mf6/example/ex-gwf-csub-p02c/hb-020",
-    "mf6/example/ex-gwf-csub-p02c/hb-050",
     "mf6/example/ex-gwf-csub-p02c/es-002",
+    "mf6/example/ex-gwf-csub-p02c/es-050",
+    "mf6/example/ex-gwf-csub-p02c/es-100",
+    "mf6/example/ex-gwf-csub-p02c/hb-002",
+    "mf6/example/ex-gwf-csub-p02c/hb-005",
 ]
 ex-gwf-csub-p03a = [
     "mf6/example/ex-gwf-csub-p03a",
@@ -228,8 +228,8 @@ ex-gwt-henry-b = [
 ]
 ex-gwt-keating = [
     "mf6/example/ex-gwt-keating/mf6gwf",
-    "mf6/example/ex-gwt-keating/mf6gwt",
     "mf6/example/ex-gwt-keating/mf6prt",
+    "mf6/example/ex-gwt-keating/mf6gwt",
 ]
 ex-gwt-moc3d-p01a = [
     "mf6/example/ex-gwt-moc3d-p01a/mf6gwf",


### PR DESCRIPTION
Also make the model order in the examples mapping deterministic (and make sure gwf comes first)