### PR TITLE
refactor(dfn): separate period block arrays in toml

### DIFF
--- a/modflow_devtools/dfn.py
+++ b/modflow_devtools/dfn.py
@@ -313,11 +313,12 @@ class Dfn(TypedDict):
             if fields[0]["type"] == "recarray":
                 assert len(fields) == 1
                 recarray_name = fields[0]["name"]
-                item = fields[0]["item"]
-                columns = item.get("fields", None)
+                item = next(iter(fields[0]["children"].values()))
+                columns = item.get("children", None)
                 if not columns:
-                    assert item["type"] == "keystring"
-                    columns = item["choices"]
+                    import pdb
+
+                    pdb.set_trace()
             else:
                 recarray_name = None
                 columns = block
@@ -403,7 +404,7 @@ class Dfn(TypedDict):
                             name=_name,
                             type="record",
                             block=block,
-                            fields=_fields(),
+                            children=_fields(),
                             description=description.replace(
                                 "is the list of", "is the record of"
                             ),
@@ -428,7 +429,7 @@ class Dfn(TypedDict):
                         name=first["name"] if single else _name,
                         type=item_type,
                         block=block,
-                        fields=first["fields"] if single else fields,
+                        children=first["children"] if single else fields,
                         description=description.replace(
                             "is the list of", f"is the {item_type} of"
                         ),
@@ -471,15 +472,16 @@ class Dfn(TypedDict):
                 )
 
                 if _type.startswith("recarray"):
-                    var_["item"] = _item()
+                    item = _item()
+                    var_["children"] = {item["name"]: item}
                     var_["type"] = "recarray"
 
                 elif _type.startswith("keystring"):
-                    var_["choices"] = _choices()
+                    var_["children"] = _choices()
                     var_["type"] = "keystring"
 
                 elif _type.startswith("record"):
-                    var_["fields"] = _fields()
+                    var_["children"] = _fields()
                     var_["type"] = "record"
 
                 # for now, we can tell a var is an array if its type

--- a/modflow_devtools/dfn.py
+++ b/modflow_devtools/dfn.py
@@ -302,11 +302,7 @@ class Dfn(TypedDict):
 
             Extracts recarray fields and creates separate array variables. Gives
             each an appropriate grid- or tdis-aligned shape as opposed to sparse
-            list shape in terms of maxbound (as previously), and sets the reader
-            field to "list" to indicate to MF6 that the arrays are to be loaded
-            together via list-based input. (This could just be inferred from the
-            block name "period" or the presence of an "iper" variable, but seems
-            better to be explicit than rely on implicit rules.)
+            list shape in terms of maxbound as previously.
             """
 
             fields = list(block.values())
@@ -314,11 +310,7 @@ class Dfn(TypedDict):
                 assert len(fields) == 1
                 recarray_name = fields[0]["name"]
                 item = next(iter(fields[0]["children"].values()))
-                columns = item.get("children", None)
-                if not columns:
-                    import pdb
-
-                    pdb.set_trace()
+                columns = item["children"]
             else:
                 recarray_name = None
                 columns = block
@@ -335,7 +327,6 @@ class Dfn(TypedDict):
                 if old_dims:
                     new_dims.extend([dim for dim in old_dims if dim != "maxbound"])
                 col_copy["shape"] = f"({', '.join(new_dims)})"
-                col_copy["reader"] = "list"
                 block[col_name] = col_copy
 
             return block

--- a/modflow_devtools/misc.py
+++ b/modflow_devtools/misc.py
@@ -565,3 +565,19 @@ def try_get_enum_value(v: Any) -> Any:
     of an enumeration, otherwise return it unaltered.
     """
     return v.value if isinstance(v, Enum) else v
+
+
+# TODO: use dataclasses instead of typed dicts? static
+# methods on typed dicts are evidently not allowed
+# mypy: ignore-errors
+
+
+def try_literal_eval(value: str) -> Any:
+    """
+    Try to parse a string as a literal. If this fails,
+    return the value unaltered.
+    """
+    try:
+        return literal_eval(value)
+    except (SyntaxError, ValueError):
+        return value


### PR DESCRIPTION
In the new TOML definition file format, define period block variables (arrays) in terms of the grid and time discretization shape, rather than in the sparse/list-based input form with shape maxbound, the latter being an MF6 input file format detail. Towards structure-scoped TOML definition files i.e. connections/contents of simulation components, whereas normal DFN files are also about input formatting.

Sample of the old format as compared to the new for the GWF CHD period block:

```
block period
name iper
type integer
block_variable True
in_record true
tagged false
shape
valid
reader urword
optional false
longname stress period number
description REPLACE iper {}

block period
name stress_period_data
type recarray cellid head aux boundname
shape (maxbound)
reader urword
longname
description
mf6internal spd

block period
name cellid
type integer
shape (ncelldim)
tagged false
in_record true
reader urword
longname cell identifier
description REPLACE cellid {}

block period
name head
type double precision
shape
tagged false
in_record true
reader urword
time_series true
longname head value assigned to constant head
description is the head at the boundary. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.

block period
name aux
type double precision
in_record true
tagged false
shape (naux)
reader urword
optional true
time_series true
longname auxiliary variables
description REPLACE aux {'{#1}': 'constant head'}
mf6internal auxvar

block period
name boundname
type string
shape
tagged false
in_record true
reader urword
optional true
longname constant head boundary name
description REPLACE boundname {'{#1}': 'constant head boundary'}

```

```toml
[period.head]
block = "period"
name = "head"
type = "double precision"
shape = "(nper, nnodes)"
time_series = "true"
longname = "head value assigned to constant head"
description = "is the head at the boundary. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."

[period.aux]
block = "period"
name = "aux"
type = "double precision"
shape = "(nper, nnodes, naux)"
optional = "true"
time_series = "true"
longname = "auxiliary variables"
description = "represents the values of the auxiliary variables for each constant head. The values of auxiliary variables must be present for each constant head. The values must be specified in the order of the auxiliary variables specified in the OPTIONS block.  If the package supports time series and the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
mf6internal = "auxvar"

[period.boundname]
block = "period"
name = "boundname"
type = "string"
shape = "(nper, nnodes)"
optional = "true"
longname = "constant head boundary name"
description = "name of the constant head boundary cell.  BOUNDNAME is an ASCII character variable that can contain as many as 40 characters.  If BOUNDNAME contains spaces in it, then the entire name must be enclosed within single quotes."
```

Dimension info previously encoded in `iper` and `cellid` is now signified as with other arrays with `shape = "(nper, nnodes)"`. These variables and the intermediate recarray variable are dropped, as they specified formatting details more than intrinsically necessary information about the data model.

Also, unrelatedly

- use key "children" for composite `Field` children, previously "items", "choices", "fields" were used for list, union, record respectively
- promote some utility functions to public naming (no leading underscore)
- add a few block-related aliases and utilities