### PR TITLE
fix(dfn): populate record's keystring fields properly

### DIFF
--- a/modflow_devtools/dfn.py
+++ b/modflow_devtools/dfn.py
@@ -460,7 +460,7 @@ class Dfn(TypedDict):
                             or v["type"].startswith("record")
                         ):
                             continue
-                        fields[name] = v
+                        fields[name] = _convert_field(v)
                     return fields
 
                 var_ = Field(


### PR DESCRIPTION
A record can be composite i.e. have keystrings as fields, these weren't included in the conversion before