### PR TITLE
feat(dfn): mark models, exgs, slns multi-components in tomls

### DIFF
--- a/modflow_devtools/dfn.py
+++ b/modflow_devtools/dfn.py
@@ -592,11 +592,19 @@ class Dfn(TypedDict):
                 return Ref(parent=parent, **rest)
             return None
 
+        sln = _sln()
+        multi = (
+            _multi()
+            or sln is not None
+            or ("nam" in name and "sim" not in name)
+            or name.startswith("exg-")
+        )
+
         return cls(
             name=name,
             advanced=_advanced(),
-            multi=_multi(),
-            sln=_sln(),
+            multi=multi,
+            sln=sln,
             ref=_sub(),
             **blocks,
         )


### PR DESCRIPTION
`multi` attribute generalizes concept of multi-package to any component whose parent can have not just one but multiple